### PR TITLE
Madrob all in one

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ MADROB-BEAST Performance Indicators
 Scripts to calculate performance indicators for the MADROB and BEAST benchmarks, from the Eurobench project.
 
 ## Installing the library
+
 Pip can be used to install this module locally:
-```
+
+```term
 git clone https://github.com/madrob-beast/madrob_beast_pi.git
 cd madrob_beast_pi
 virtualenv -p /usr/bin/python2.7 venv
@@ -15,11 +17,12 @@ pip install -e src/madrob_beast_pi
 ```
 
 Using the virtual environment, the package and dependencies is installed locally in the folder `venv`.
-To desactivate the virtual environment, type `deactivate`.
+To deactivate the virtual environment, type `deactivate`.
 
 To install permanently the code, only use the last command.
 
-**Note**: When adding or modifying Performance Indicators, run the installation command again. To keep the PIs up-to-date, run `git pull` and the installation command.
+**Note**: When adding or modifying Performance Indicators, run the installation command again.
+To keep the PIs up-to-date, run `git pull` and the installation command.
 
 ## Usage
 
@@ -35,30 +38,36 @@ run_madrob tests/madrob/input/events.csv tests/madrob/input/wrench.csv tests/mad
 
 The Dockerfile in this project can be used to build Docker images for every PI:
 when building, set the `BENCHMARK_TYPE` and `PI_NAME` params to the specific PI ones. E.g. for the 'madrob' benchmark, Performance Indicator 'execution_time':
-```
+
+```term
 docker build --build-arg BENCHMARK_TYPE=madrob --build-arg PI_NAME=execution_time -t=madrob_execution_time .
 ```
-This creates an image named `madrob_execution_time`. (The `make_docker_images.py` script can create all required images, as mentioned below).
 
-If we run a container from this image and call the `run_pi` command, 
+This creates an image named `madrob_execution_time` (the `make_docker_images.py` script can create all required images, as mentioned below).
+
+If we run a container from this image and call the `run_pi` command,
 the Performance Indicator will be run.
 
 Assuming `test_data/` contains input data, and the output directory `out_folder/` exists:
-```
+
+```term
 docker run --rm -v $PWD/test_data:/in -v $PWD/out_folder:/out madrob_execution_time ./run_pi /in/events.csv /in/testbed_config.yaml /out
 ```
 
 ## Creating all Docker images
 
 The script `make_docker_images.py` builds Docker images for all the Performance Indicators in the 'madrob' and 'beast' directories:
-```
+
+```term
 python make_docker_images.py
 ```
+
 **Note**: The script runs `"sudo docker ..."`. To run docker in user mode, modify the script.
 
 ## Test data
 
-The `test_data/` directory contains preprocessed `.csv` files and a testbed configuration `.yaml` file. These files are from a real benchmark run, and can be used as test input to the `run_pi` command.
+The [tests](tests) directory contains preprocessed `.csv` files and a testbed configuration `.yaml` file.
+These files are from a real benchmark run, and can be used as test input to the `run_pi` command.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,28 @@ Pip can be used to install this module locally:
 ```
 git clone https://github.com/madrob-beast/madrob_beast_pi.git
 cd madrob_beast_pi
-python -m pip install src/madrob_beast_pi/
+virtualenv -p /usr/bin/python2.7 venv
+source venv/bin/activate
+#python -m pip install src/madrob_beast_pi/
+pip install -e src/madrob_beast_pi
 ```
 
+Using the virtual environment, the package and dependencies is installed locally in the folder `venv`.
+To desactivate the virtual environment, type `deactivate`.
+
+To install permanently the code, only use the last command.
+
 **Note**: When adding or modifying Performance Indicators, run the installation command again. To keep the PIs up-to-date, run `git pull` and the installation command.
+
+## Usage
+
+### Madrob
+
+All PI associated to madrob can be launched using (Assuming folder `out_tests` exists):
+
+```term
+run_madrob tests/madrob/input/events.csv tests/madrob/input/wrench.csv tests/madrob/input/jointState.csv tests/madrob/input/testbed_config.yaml out_tests
+```
 
 ## Docker
 

--- a/src/madrob_beast_pi/madrob/capability_level.py
+++ b/src/madrob_beast_pi/madrob/capability_level.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # coding=utf-8
 
 import yaml
@@ -52,7 +52,16 @@ def performance_indicator(preprocessed_filenames_dict, testbed_conf, output_dir,
         }, result_file, default_flow_style=False)
 
 
-if __name__ == '__main__':
+def run_pi(events_path, testbed_conf_path, output_folder_path):
+
+    with open(testbed_conf_path, 'r') as testbed_conf_file:
+        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
+
+    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+    return 0
+
+
+def main ():
     arg_len = 4
     script_name = 'capability_level'
     if len(argv) != arg_len:
@@ -61,7 +70,8 @@ if __name__ == '__main__':
 
     events_path, testbed_conf_path, output_folder_path = argv[1:]
 
-    with open(testbed_conf_path, 'r') as testbed_conf_file:
-        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
+    return run_pi(events_path, testbed_conf_path, output_folder_path)
 
-    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+
+if __name__ == '__main__':
+    main()

--- a/src/madrob_beast_pi/madrob/door_handle_smoothness.py
+++ b/src/madrob_beast_pi/madrob/door_handle_smoothness.py
@@ -28,6 +28,12 @@ def performance_indicator(preprocessed_filenames_dict, _, output_dir, start_time
             'value': float(smoothness),
         }, result_file, default_flow_style=False)
 
+    return 0
+
+
+def run_pi(wrench_path, output_folder_path):
+    return performance_indicator({'wrench': wrench_path}, None, output_folder_path, datetime.now())
+
 
 if __name__ == '__main__':
     arg_len = 3

--- a/src/madrob_beast_pi/madrob/door_occupation_time.py
+++ b/src/madrob_beast_pi/madrob/door_occupation_time.py
@@ -45,6 +45,14 @@ def performance_indicator(preprocessed_filenames_dict, testbed_conf, output_dir,
         }, result_file, default_flow_style=False)
 
 
+def run_pi(events_path, testbed_conf_path, output_folder_path):
+    with open(testbed_conf_path, 'r') as testbed_conf_file:
+        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
+
+    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+    return 0
+
+
 if __name__ == '__main__':
     arg_len = 4
     script_name = 'door_occupation_time'
@@ -54,7 +62,4 @@ if __name__ == '__main__':
 
     events_path, testbed_conf_path, output_folder_path = argv[1:]
 
-    with open(testbed_conf_path, 'r') as testbed_conf_file:
-        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
-
-    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+    run_pi(events_path, testbed_conf_path, output_folder_path)

--- a/src/madrob_beast_pi/madrob/execution_time.py
+++ b/src/madrob_beast_pi/madrob/execution_time.py
@@ -43,6 +43,14 @@ def performance_indicator(preprocessed_filenames_dict, testbed_conf, output_dir,
         }, result_file, default_flow_style=False)
 
 
+def run_pi(events_path, testbed_conf_path, output_folder_path):
+    with open(testbed_conf_path, 'r') as testbed_conf_file:
+        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
+
+    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+    return 0
+
+
 if __name__ == '__main__':
     arg_len = 4
     script_name = 'execution_time'
@@ -52,7 +60,4 @@ if __name__ == '__main__':
 
     events_path, testbed_conf_path, output_folder_path = argv[1:]
 
-    with open(testbed_conf_path, 'r') as testbed_conf_file:
-        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
-
-    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+    run_pi(events_path, testbed_conf_path, output_folder_path)

--- a/src/madrob_beast_pi/madrob/passage_time.py
+++ b/src/madrob_beast_pi/madrob/passage_time.py
@@ -48,6 +48,14 @@ def performance_indicator(preprocessed_filenames_dict, testbed_conf, output_dir,
         }, result_file, default_flow_style=False)
 
 
+def run_pi(events_path, testbed_conf_path, output_folder_path):
+    with open(testbed_conf_path, 'r') as testbed_conf_file:
+        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
+
+    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+    return 0
+
+
 if __name__ == '__main__':
     arg_len = 4
     script_name = 'passage_time'
@@ -57,7 +65,4 @@ if __name__ == '__main__':
 
     events_path, testbed_conf_path, output_folder_path = argv[1:]
 
-    with open(testbed_conf_path, 'r') as testbed_conf_file:
-        testbed_conf_dict = yaml.safe_load(testbed_conf_file)
-
-    performance_indicator({'events': events_path}, testbed_conf_dict, output_folder_path, datetime.now())
+    run_pi(events_path, testbed_conf_path, output_folder_path)

--- a/src/madrob_beast_pi/madrob/roughness_of_door_actuation.py
+++ b/src/madrob_beast_pi/madrob/roughness_of_door_actuation.py
@@ -30,6 +30,11 @@ def performance_indicator(preprocessed_filenames_dict, _, output_dir, start_time
         }, result_file, default_flow_style=False)
 
 
+def run_pi(wrench_path, output_folder_path):
+    performance_indicator({'wrench': wrench_path}, None, output_folder_path, datetime.now())
+    return 0
+
+
 if __name__ == '__main__':
     arg_len = 3
     script_name = 'roughness_of_door_actuation'
@@ -38,4 +43,4 @@ if __name__ == '__main__':
         exit(-1)
 
     wrench_path, output_folder_path = argv[1:]
-    performance_indicator({'wrench': wrench_path}, None, output_folder_path, datetime.now())
+    run_pi(wrench_path, output_folder_path)

--- a/src/madrob_beast_pi/madrob/smoothness_of_door_actuation.py
+++ b/src/madrob_beast_pi/madrob/smoothness_of_door_actuation.py
@@ -30,6 +30,11 @@ def performance_indicator(preprocessed_filenames_dict, _, output_dir, start_time
         }, result_file, default_flow_style=False)
 
 
+def run_pi(joint_state_path, output_folder_path):
+    performance_indicator({'jointState': joint_state_path}, None, output_folder_path, datetime.now())
+    return 0
+
+
 if __name__ == '__main__':
     arg_len = 3
     script_name = 'smoothness_of_door_actuation'
@@ -38,4 +43,4 @@ if __name__ == '__main__':
         exit(-1)
 
     joint_state_path, output_folder_path = argv[1:]
-    performance_indicator({'jointState': joint_state_path}, None, output_folder_path, datetime.now())
+    run_pi(joint_state_path, output_folder_path)

--- a/src/madrob_beast_pi/madrob/time_to_handle.py
+++ b/src/madrob_beast_pi/madrob/time_to_handle.py
@@ -31,6 +31,11 @@ def performance_indicator(preprocessed_filenames_dict, _, output_dir, start_time
         }, result_file, default_flow_style=False)
 
 
+def run_pi(events_path, output_folder_path):
+    performance_indicator({'events': events_path}, None, output_folder_path, datetime.now())
+    return 0
+
+
 if __name__ == '__main__':
     arg_len = 3
     script_name = 'time_to_handle'
@@ -39,4 +44,4 @@ if __name__ == '__main__':
         exit(-1)
 
     events_path, output_folder_path = argv[1:]
-    performance_indicator({'events': events_path}, None, output_folder_path, datetime.now())
+    run_pi(events_path, output_folder_path)

--- a/src/madrob_beast_pi/madrob/unsafety_of_door_operation.py
+++ b/src/madrob_beast_pi/madrob/unsafety_of_door_operation.py
@@ -49,6 +49,11 @@ def performance_indicator(preprocessed_filenames_dict, _, output_dir, start_time
         }, result_file, default_flow_style=False)
 
 
+def run_pi(joint_state_path, output_folder_path):
+    performance_indicator({'jointState': joint_state_path}, None, output_folder_path, datetime.now())
+    return 0
+
+
 if __name__ == '__main__':
     arg_len = 3
     script_name = 'unsafety_of_door_operation'
@@ -57,4 +62,4 @@ if __name__ == '__main__':
         exit(-1)
 
     joint_state_path, output_folder_path = argv[1:]
-    performance_indicator({'jointState': joint_state_path}, None, output_folder_path, datetime.now())
+    run_pi(joint_state_path, output_folder_path)

--- a/src/madrob_beast_pi/script/run_madrob
+++ b/src/madrob_beast_pi/script/run_madrob
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+
+import sys
+from madrob import capability_level
+from madrob import door_handle_smoothness
+from madrob import door_occupation_time
+from madrob import execution_time
+from madrob import passage_time
+from madrob import roughness_of_door_actuation
+from madrob import smoothness_of_door_actuation
+from madrob import time_to_handle
+from madrob import unsafety_of_door_operation
+
+
+USAGE = """usage: madrob events.csv wrench.csv joint_state.csv testbed_config.yaml output_dir
+events.csv: TOBEDEFINED
+wrench.csv: TOBEDEFINED
+joint_state.csv: TOBEDEFINED
+testbed_config.yaml: TOBEDEFINED
+"""
+
+
+if __name__ == '__main__':
+
+    print "MADROB PI compuation"
+
+    arg_len = 6
+    if len(sys.argv) != arg_len:
+        print USAGE
+        sys.exit(-1)
+
+    print "Runing pi capability level"
+    events_path, wrench_path, joint_state_path, testbed_conf_path, output_folder_path = sys.argv[1:]
+
+    is_ok = capability_level.run_pi(events_path, testbed_conf_path, output_folder_path)
+    if not is_ok == 0:
+        sys.exit(is_ok)
+
+    print "Runing pi door_handle_smoothness"
+    is_ok = door_handle_smoothness.run_pi(wrench_path, output_folder_path)
+    if (not is_ok == 0):
+        sys.exit(is_ok)
+
+    print "Runing pi door_occupation_time"
+    is_ok = door_occupation_time.run_pi(events_path, testbed_conf_path, output_folder_path)
+    if not is_ok == 0:
+        sys.exit(is_ok)
+
+    print "Runing pi execution_time"
+    is_ok = execution_time.run_pi(events_path, testbed_conf_path, output_folder_path)
+    if not is_ok == 0:
+        sys.exit(is_ok)
+
+    print "Runing pi passage_time"
+    is_ok = passage_time.run_pi(events_path, testbed_conf_path, output_folder_path)
+    if not is_ok == 0:
+        sys.exit(is_ok)
+
+    print "Runing pi roughness_of_door_actuation"
+    is_ok = roughness_of_door_actuation.run_pi(wrench_path, output_folder_path)
+    if (not is_ok == 0):
+        sys.exit(is_ok)
+
+    print "Runing pi smoothness_of_door_actuation"
+    is_ok = smoothness_of_door_actuation.run_pi(joint_state_path, output_folder_path)
+    if (not is_ok == 0):
+        sys.exit(is_ok)
+
+    print "Runing pi time_to_handle"
+    is_ok = time_to_handle.run_pi(events_path, output_folder_path)
+    if (not is_ok == 0):
+        sys.exit(is_ok)
+
+    print "Runing pi smoothness_of_door_actuation"
+    is_ok = unsafety_of_door_operation.run_pi(joint_state_path, output_folder_path)
+    if (not is_ok == 0):
+        sys.exit(is_ok)
+
+
+    print "All computation done"
+    sys.exit(0)

--- a/src/madrob_beast_pi/setup.py
+++ b/src/madrob_beast_pi/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     python_requires='>=2.7.12',
+    scripts=['script/run_madrob'],
     install_requires=[
         'pyyaml==5.3',
         'numpy==1.16.6',


### PR DESCRIPTION
This is a suggestion for easing the computation.
I create a script `madrob`. By defining it within the package, it gets automatically usable from anywhere once your package is installed.

The script calls all the PI modules related to madrob. To enable this, I had to adust slighlty your PI files. basically, I restricted all the mains to chekcing input parameters, and then call a local run_pi function, which can be directly reused from the global script.

Note that the call of the program as you were doing before is still possible. 

If this approach sounds good to you, a similar approach could be used for beast  