### PR TITLE
add deploy mechanism

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy Docker image
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check secret available
+      env:
+        SECRET_DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        SECRET_DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      run: |
+        if [[ -z "$SECRET_DOCKERHUB_PASSWORD" ]]; then
+          echo "Missing variable SECRET_DOCKERHUB_PASSWORD"
+          exit 1
+        fi
+        if [[ -z "$SECRET_DOCKERHUB_USERNAME" ]]; then
+          echo "Missing variable SECRET_DOCKERHUB_USERNAME"
+          exit 1
+        fi
+    - name: Get latest release version number
+      id: get_version
+      uses: battila7/get-version-action@v2
+    - name: Check image name
+      env:
+        REPO_NAME: ${{ github.event.repository.name }}
+        VERSION: ${{ steps.get_version.outputs.version }}
+      run: echo "docker image name would be $REPO_NAME:$VERSION"
+    - name: Login to DockerHub Registry
+      run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+    - name: Build the Docker image
+      env:
+        REPO_NAME: ${{ github.event.repository.name }}
+        VERSION: ${{ steps.get_version.outputs.version }}
+      run: docker build . --file Dockerfile --tag eurobenchtest/$REPO_NAME:$VERSION
+    - name: Get the docker image testing material
+      run: wget -O test_docker_call.py https://raw.githubusercontent.com/eurobench/docker_test/master/test_docker_call.py
+    - name: test the Docker image
+      env:
+        DOCKER_IMAGE: eurobenchtest/${{ github.event.repository.name }}:${{ steps.get_version.outputs.version }}
+        TEST_PLAN: tests/test_plan.xml
+      run:  python3 test_docker_call.py
+    - name: Push to Docker hub
+      env:
+        REPO_NAME: ${{ github.event.repository.name }}
+        VERSION: ${{ steps.get_version.outputs.version }}
+      run: docker push eurobenchtest/$REPO_NAME:$VERSION


### PR DESCRIPTION
Yet another CI flow, for deploying the docker image onto [eurobenchtest](https://hub.docker.com/orgs/eurobenchtest/repositories)
Now the idea would be that this would be done from my fork (so that we keep the control on when a deploy is being deployed).

We could argue whether it makes sense to bring this into your repo, or whether we should keep it here in our fork. I am open to discussion.